### PR TITLE
WAAT For Mobile [Android]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     compile 'com.thoughtworks.xstream:xstream:1.3.1'
     compile 'net.lightbody.bmp:browsermob-core:2.1.2'
     compile 'org.seleniumhq.selenium:selenium-java:2.53.1'
+    compile group: 'io.appium', name: 'java-client', version: '4.1.1'
 
     testCompile 'org.testng:testng:6.9.10'
     testCompile 'org.uncommons:reportng:1.1.4'

--- a/resources/mobileSetUp.properties
+++ b/resources/mobileSetUp.properties
@@ -1,0 +1,3 @@
+BROWSER_NAME:Chrome
+PLATFORM_NAME:Android
+DEVICE_NAME:AndroidEmulator

--- a/src/main/java/com/thoughtworks/webanalyticsautomation/Engine.java
+++ b/src/main/java/com/thoughtworks/webanalyticsautomation/Engine.java
@@ -87,18 +87,14 @@ public class Engine extends CONFIG {
     }
 
     private Result verifyWebAnalyticsData(String actionName, ArrayList<Section> actualSectionList, ArrayList<Section> expectedSectionList) {
-        System.out.println("+++++++++++++++++++++++++++++Inside web analytics enabled ++++++++++++++++++++++++++++++++++++++++++");
         if ((actualSectionList.size() == 0) && (expectedSectionList.size() != 0)) {
-            System.out.println("Done1");
             return new Result(actionName, Status.FAIL, getAllTagsFromExpectedSectionList(expectedSectionList));
         } else {
-            System.out.println("Done2");
             ArrayList<String> errorList = new ArrayList<String>();
             for (Section expectedSection : expectedSectionList) {
                 errorList.addAll(getListOfMissingTagsInActualSections(actualSectionList, expectedSection));
             }
             if (errorList.size() != 0) {
-                System.out.println("Done3");
                 errorList.addAll(addActualSectionsInErrorList(actualSectionList));
             }
             return new Result(actionName, errorList);

--- a/src/main/java/com/thoughtworks/webanalyticsautomation/Engine.java
+++ b/src/main/java/com/thoughtworks/webanalyticsautomation/Engine.java
@@ -87,14 +87,18 @@ public class Engine extends CONFIG {
     }
 
     private Result verifyWebAnalyticsData(String actionName, ArrayList<Section> actualSectionList, ArrayList<Section> expectedSectionList) {
+        System.out.println("+++++++++++++++++++++++++++++Inside web analytics enabled ++++++++++++++++++++++++++++++++++++++++++");
         if ((actualSectionList.size() == 0) && (expectedSectionList.size() != 0)) {
+            System.out.println("Done1");
             return new Result(actionName, Status.FAIL, getAllTagsFromExpectedSectionList(expectedSectionList));
         } else {
+            System.out.println("Done2");
             ArrayList<String> errorList = new ArrayList<String>();
             for (Section expectedSection : expectedSectionList) {
                 errorList.addAll(getListOfMissingTagsInActualSections(actualSectionList, expectedSection));
             }
             if (errorList.size() != 0) {
+                System.out.println("Done3");
                 errorList.addAll(addActualSectionsInErrorList(actualSectionList));
             }
             return new Result(actionName, errorList);
@@ -181,6 +185,12 @@ public class Engine extends CONFIG {
         logger.debug("Get Selenium Based Proxy Plugin");
         WaatPlugin pluginInstance = PluginFactory.getWebAnalyticsPluginInstance(CONFIG.getWEB_ANALYTIC_TOOL());
         return pluginInstance.getSeleniumProxy(0);
+    }
+
+    public Object getAppiumBasedProxyPlugin(){
+        logger.info("Get Appium Based Proxy Plugin");
+        WaatPlugin pluginInstance = PluginFactory.getWebAnalyticsPluginInstance(CONFIG.getWEB_ANALYTIC_TOOL());
+        return pluginInstance.getSeleniumProxy(5555);
     }
 
 }

--- a/src/main/java/com/thoughtworks/webanalyticsautomation/plugins/ProxyDebugger.java
+++ b/src/main/java/com/thoughtworks/webanalyticsautomation/plugins/ProxyDebugger.java
@@ -34,9 +34,16 @@ public class ProxyDebugger implements WaatPlugin {
         Har har = proxy.getHar();
         List<HarEntry> entries = har.getLog().getEntries();
         ArrayList<Section> capturedSections = new ArrayList<>();
-        logger.debug("Number of requests captured - " + entries.size());
-        logger.debug("Number of matching URLs to be found - " + minimumNumberOfPackets);
+        logger.info("Number of requests captured - " + entries.size());
+        logger.info("Number of matching URLs to be found - " + minimumNumberOfPackets);
         int numberOfPacketsCaptured = entries.size();
+
+        logger.info("******************************************** URL captured ********************************************");
+        for (HarEntry entry : entries){
+            System.out.println(entry.getRequest().getUrl());
+        }
+        logger.info("******************************************** URL captured ********************************************");
+
         for (int packetNumber=numberOfPacketsCaptured-1; packetNumber>=0 && minimumNumberOfPackets>0; packetNumber--)
         {
             HarEntry entry = entries.get(packetNumber);
@@ -104,7 +111,7 @@ public class ProxyDebugger implements WaatPlugin {
 
     @Override
     public BrowserMobProxy getProxy(int port) {
-        logger.info("getProxy - " + port);
+        logger.info("Initializing BrowserMobProxy for the port - " + port);
         proxy= new BrowserMobProxyServer();
         proxy.start(port);
         proxy.enableHarCaptureTypes(CaptureType.REQUEST_HEADERS,
@@ -128,8 +135,8 @@ public class ProxyDebugger implements WaatPlugin {
 
     @Override
     public Object getSeleniumProxy(int port) {
-        logger.info ("Get Selenium");
-        BrowserMobProxy proxy = this.getProxy(0);
+        logger.info ("Get Proxy for the port "+ port);
+        BrowserMobProxy proxy = this.getProxy(port);
         return ClientUtil.createSeleniumProxy(proxy);
     }
 }

--- a/src/test/java/com/thoughtworks/webanalyticsautomation/samples/VerifyWebAnalyticsForAndroid.java
+++ b/src/test/java/com/thoughtworks/webanalyticsautomation/samples/VerifyWebAnalyticsForAndroid.java
@@ -1,0 +1,98 @@
+package com.thoughtworks.webanalyticsautomation.samples;
+
+import com.thoughtworks.webanalyticsautomation.Controller;
+import com.thoughtworks.webanalyticsautomation.Engine;
+import com.thoughtworks.webanalyticsautomation.Result;
+import com.thoughtworks.webanalyticsautomation.Status;
+import com.thoughtworks.webanalyticsautomation.common.BROWSER;
+import com.thoughtworks.webanalyticsautomation.common.TestBase;
+import com.thoughtworks.webanalyticsautomation.common.Utils;
+import com.thoughtworks.webanalyticsautomation.inputdata.InputFileType;
+import com.thoughtworks.webanalyticsautomation.plugins.WebAnalyticTool;
+import com.thoughtworks.webanalyticsautomation.scriptrunner.helper.MobileDriverScriptRunnerHelper;
+import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.MobileElement;
+import org.apache.log4j.Logger;
+import org.openqa.selenium.Proxy;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import java.io.IOException;
+import java.util.ArrayList;
+import static com.thoughtworks.webanalyticsautomation.Controller.getInstance;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Created by gshilpa on 8/25/16.
+ */
+public class VerifyWebAnalyticsForAndroid extends TestBase{
+
+
+    protected static AndroidDriver<MobileElement> driverAndroid;
+    private Logger logger = Logger.getLogger(getClass());
+    private Engine engine;
+    private WebAnalyticTool webAnalyticTool = WebAnalyticTool.PROXY;
+    private InputFileType inputFileType = InputFileType.XML;
+    private boolean keepLoadedFileInMemory = true;
+    private String log4jPropertiesAbsoluteFilePath = Utils.getAbsolutePath(new String[] {"resources","log4j.properties"});
+    private String inputDataFileName = Utils.getAbsolutePath(new String[] {"src", "test", "sampledata", "TestData.xml"});
+    private String actionName = "OpenWAATArticleOnBlog_Proxy";
+    private MobileDriverScriptRunnerHelper mobileDriverScirptRunnerHelper;
+
+
+    @BeforeMethod
+    public void setup () throws IOException {
+        Controller.reset();
+    }
+
+    @Test
+    public void captureVerifyAnalyticsDataForAndroidMobile()
+    {
+        String baseURL = "http://essenceoftesting.blogspot.com";
+        String navigateToURL = baseURL + "/search/label/waat";
+        ArrayList<String> urlPatterns = new ArrayList<String>();
+        urlPatterns.add("https://ssl.google-analytics.com/__");
+        int minimumNumberOfPackets = 1;
+        engine = getInstance(webAnalyticTool, inputFileType, keepLoadedFileInMemory, log4jPropertiesAbsoluteFilePath);
+        Proxy mobileProxy=(Proxy) engine.getAppiumBasedProxyPlugin();
+        startMobileDriver(BROWSER.chrome, baseURL, mobileProxy);
+        logger.info("********************************************Start capture********************************************");
+        engine.enableWebAnalyticsTesting(actionName);
+        logger.info("********************************************Do action********************************************");
+        driverAndroid.get(navigateToURL);
+        try {
+            Thread.sleep(10000);
+            logger.info("Waiting for application to load");
+        } catch (InterruptedException e) {
+            logger.error(e.getMessage());
+        }
+        logger.info("********************************************Verify result********************************************");
+        Result verificationResult = engine.verifyWebAnalyticsData(inputDataFileName, actionName, urlPatterns, minimumNumberOfPackets);
+        logger.info("********************************************Verification pattern should not be null********************************************");
+        assertNotNull(verificationResult.getVerificationStatus(), "Verification status should NOT be NULL");
+        logger.info("********************************************Failure details should NOT be NULL********************************************");
+        assertNotNull(verificationResult.getListOfErrors(), "Failure details should NOT be NULL");
+        logVerificationErrors(verificationResult);
+        logger.info("********************************************Verification status should be PASS********************************************");
+        assertEquals(verificationResult.getVerificationStatus(), Status.PASS, "Verification status should be PASS");
+        logger.info("********************************************Failure details should be empty********************************************");
+        assertEquals(verificationResult.getListOfErrors().size(), 0, "Failure details should be empty");
+    }
+
+    private void startMobileDriver(BROWSER browser, String baseURL, Proxy mobileProxy) {
+        mobileDriverScirptRunnerHelper = new MobileDriverScriptRunnerHelper(logger, browser, baseURL);
+        mobileDriverScirptRunnerHelper.startDriverUsingProxy(mobileProxy);
+        driverAndroid = (AndroidDriver<MobileElement>) mobileDriverScirptRunnerHelper.getDriverInstance();
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        if (engine!=null) {
+            engine.disableWebAnalyticsTesting();
+        }
+        if (mobileDriverScirptRunnerHelper!=null) {
+            mobileDriverScirptRunnerHelper.stopDriver();
+        }
+    }
+}

--- a/src/test/java/com/thoughtworks/webanalyticsautomation/scriptrunner/helper/MobileDriverScriptRunnerHelper.java
+++ b/src/test/java/com/thoughtworks/webanalyticsautomation/scriptrunner/helper/MobileDriverScriptRunnerHelper.java
@@ -1,0 +1,102 @@
+package com.thoughtworks.webanalyticsautomation.scriptrunner.helper;
+
+import com.thoughtworks.webanalyticsautomation.common.BROWSER;
+import com.thoughtworks.webanalyticsautomation.common.Utils;
+import io.appium.java_client.MobileElement;
+import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.remote.AndroidMobileCapabilityType;
+import io.appium.java_client.remote.MobileCapabilityType;
+import io.appium.java_client.service.local.AppiumDriverLocalService;
+import io.appium.java_client.service.local.AppiumServiceBuilder;
+import org.apache.log4j.Logger;
+import org.openqa.selenium.Proxy;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.CapabilityType;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * Created by gshilpa on 8/25/16.
+ */
+public class MobileDriverScriptRunnerHelper extends ScriptRunnerHelper{
+
+    private  AppiumDriverLocalService service;
+    private  AppiumServiceBuilder serBuilder;
+    private  AndroidDriver<MobileElement> driverAndroid;
+    FileInputStream input;
+    Properties prop=new Properties();
+
+    public MobileDriverScriptRunnerHelper(Logger logger, BROWSER browser, String baseURL) {
+        super(logger,browser, baseURL);
+    }
+
+    @Override
+    public void startDriver() {
+    }
+
+    private void instantiateChromeDriver(DesiredCapabilities capabilities) {
+        driverAndroid =new AndroidDriver<>(service.getUrl(), capabilities);
+        driverAndroid.get(BASE_URL);
+    }
+
+    @Override
+    public void startDriverUsingProxy(Proxy proxy) {
+
+        String mobilePropertyFilePath = Utils.getAbsolutePath(new String[] {"resources","mobileSetUp.properties"});
+        try {
+
+            input= new FileInputStream(mobilePropertyFilePath);
+            prop.load(input);
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        logger.info("Initializing the appium server at port 7000");
+        serBuilder=new AppiumServiceBuilder().withAppiumJS(new File("/usr/local/lib/node_modules/appium/build/lib/main.js")).usingPort(7000);
+        service = serBuilder.build();
+        service.start();
+
+        if (service == null || !service.isRunning()) {
+            throw new RuntimeException("Unable to start Appium node server");
+        }
+
+        DesiredCapabilities capabilities = new DesiredCapabilities();
+        if(browser.equals(BROWSER.chrome))
+        {
+            capabilities.setCapability(MobileCapabilityType.BROWSER_NAME, prop.getProperty("BROWSER_NAME"));
+            capabilities.setCapability(MobileCapabilityType.DEVICE_NAME, prop.getProperty("DEVICE_NAME"));
+            capabilities.setCapability(MobileCapabilityType.ACCEPT_SSL_CERTS, true);
+            ChromeOptions chromeOptions = new ChromeOptions();
+            chromeOptions.addArguments("ignore-certificate-errors");
+            capabilities.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
+            capabilities.setCapability(AndroidMobileCapabilityType.AVD_LAUNCH_TIMEOUT, 500000);
+            capabilities.setCapability(CapabilityType.PROXY, proxy);
+            instantiateChromeDriver(capabilities);
+        }
+        logger.info ("Mobile Driver started: " + browser.name());
+        logger.info ("Page title: " + driverAndroid.getTitle());
+    }
+
+    @Override
+    public void stopDriver() {
+        if(null !=this.driverAndroid)
+        driverAndroid.quit();
+    }
+
+    @Override
+    public Object getDriverInstance() {
+        if (null == driverAndroid) {
+            logger.info("Driver is null");
+        }
+        return driverAndroid;
+    }
+
+
+}


### PR DESCRIPTION
@anandbagmar 

This PR is regarding WAAT for Android Mobile Web App.
We can execute the WAAT for single device (Emulator/Real Device). This helps us to capture the network traffic for the Mobile Web app by setting up proxy using BrowserMob Proxy.

Regards,
Shilpa G
