### PR TITLE
WAAT For Mobile [Android]- Formatting the test to capture google analytics.

### DIFF
--- a/src/main/java/com/thoughtworks/webanalyticsautomation/Engine.java
+++ b/src/main/java/com/thoughtworks/webanalyticsautomation/Engine.java
@@ -87,17 +87,20 @@ public class Engine extends CONFIG {
     }
 
     private Result verifyWebAnalyticsData(String actionName, ArrayList<Section> actualSectionList, ArrayList<Section> expectedSectionList) {
-        if ((actualSectionList.size() == 0) && (expectedSectionList.size() != 0)) {
+        if ((actualSectionList.size() == 0) && (expectedSectionList.size() != 0))
+        {
             return new Result(actionName, Status.FAIL, getAllTagsFromExpectedSectionList(expectedSectionList));
-        } else {
+        }
+        else
+            {
             ArrayList<String> errorList = new ArrayList<String>();
             for (Section expectedSection : expectedSectionList) {
                 errorList.addAll(getListOfMissingTagsInActualSections(actualSectionList, expectedSection));
             }
-            if (errorList.size() != 0) {
-                errorList.addAll(addActualSectionsInErrorList(actualSectionList));
-            }
-            return new Result(actionName, errorList);
+                if (errorList.size() != 0) {
+                 errorList.addAll(addActualSectionsInErrorList(actualSectionList));
+                }
+            return new Result(actionName,errorList);
         }
     }
 
@@ -155,10 +158,9 @@ public class Engine extends CONFIG {
         boolean isExpectedTagPresent = false;
         //Done pattern matching to support variable values
         Pattern pattern = Pattern.compile(expectedTag);
-
         for (String actualTag : actualSectionTagList) {
             Matcher matcher = pattern.matcher(actualTag);
-            boolean result = matcher.matches();
+            boolean result = matcher.find();
             if (result) {
                 isExpectedTagPresent = true;
                 logger.debug("TAG FOUND: " + expectedTag);

--- a/src/test/java/com/thoughtworks/webanalyticsautomation/samples/VerifyWebAnalyticsForAndroid.java
+++ b/src/test/java/com/thoughtworks/webanalyticsautomation/samples/VerifyWebAnalyticsForAndroid.java
@@ -36,7 +36,7 @@ public class VerifyWebAnalyticsForAndroid extends TestBase{
     private InputFileType inputFileType = InputFileType.XML;
     private boolean keepLoadedFileInMemory = true;
     private String log4jPropertiesAbsoluteFilePath = Utils.getAbsolutePath(new String[] {"resources","log4j.properties"});
-    private String inputDataFileName = Utils.getAbsolutePath(new String[] {"src", "test", "sampledata", "TestData.xml"});
+    private String inputDataFileName = Utils.getAbsolutePath(new String[] {"src", "test", "sampledata", "MobileTestData.xml"});
     private String actionName = "OpenWAATArticleOnBlog_Proxy";
     private MobileDriverScriptRunnerHelper mobileDriverScirptRunnerHelper;
 
@@ -49,10 +49,10 @@ public class VerifyWebAnalyticsForAndroid extends TestBase{
     @Test
     public void captureVerifyAnalyticsDataForAndroidMobile()
     {
-        String baseURL = "http://essenceoftesting.blogspot.com";
-        String navigateToURL = baseURL + "/search/label/waat";
+        String baseURL = "https://www.thoughtworks.com";
+        String navigateToURL = baseURL + "/mingle/signup/";
         ArrayList<String> urlPatterns = new ArrayList<String>();
-        urlPatterns.add("https://ssl.google-analytics.com/__");
+        urlPatterns.add("https://www.google-analytics.com/");
         int minimumNumberOfPackets = 1;
         engine = getInstance(webAnalyticTool, inputFileType, keepLoadedFileInMemory, log4jPropertiesAbsoluteFilePath);
         Proxy mobileProxy=(Proxy) engine.getAppiumBasedProxyPlugin();

--- a/src/test/sampledata/MobileTestData.xml
+++ b/src/test/sampledata/MobileTestData.xml
@@ -1,0 +1,54 @@
+<!--
+        Sample Test Specification File
+
+        * Created by: Shilpa G
+        * Email: shilpag.398ckm@gmail.com
+        * Date: Aug 26, 2016
+        * Time: 2:16 PM
+        *
+        * Copyright 2010 Anand Bagmar (abagmar@gmail.com).  Distributed under the Apache 2.0 License
+-->
+
+<!--
+                                README for TestData specification
+
+        Section:
+                        A set of test data which includes the actionName for which
+                        the provided list of tags needs to be verified.
+
+        actionName:
+                        A (String) name representing the action done in the UI,
+                        for which we want to do Web Analytics Testing.
+
+        numberOfEventsTriggered:
+                        The number of events that "should" be triggered for the
+                        actionName specified.
+                        The (numerical) value provided for this attribute indicates
+                        the number of requests sent to the Web Analytic system for
+                        the action.
+
+        tagList:
+                        A delimited set of tags that you want to verify from any of
+                        the requests sent to analytics tool on the action performed.
+                        The tags specified are order independent, and case-SENSITIVE.
+
+                        NOTE: If you are using OmnitureDebugger, the tags are seen
+                        differently based on the UI Testing Framework being used.
+                        This is because of the difference in the way JavaScript is
+                        executed and results being interpreted by the individual
+                        UI framework.
+
+                        See the examples below for:
+                         > actionName: OpenUpcomingPage_OmnitureDebugger_Selenium
+                         > actionName: OpenUpcomingPage_OmnitureDebugger_WebDriver
+
+        delimiter:
+                        A separator used to distinguish between tags.
+                        || is the delimiter used in WAAT.
+-->
+
+<Sections>
+    <Section actionName="OpenWAATArticleOnBlog_Proxy"
+             numberOfEventsTriggered="1"
+             tagList="dt:Sign Up | Mingle||"/>
+</Sections>


### PR DESCRIPTION
@anandbagmar 
This PR helps to capture and verify the google analytics data using BrowserMobProxy for Android Mobile devices . Works For Mobile Chrome app only.

Regards,
Shilpa
